### PR TITLE
[chore] 백엔드 메인 도메인 초기 코드 업로드

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,11 +25,21 @@ repositories {
 }
 
 dependencies {
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    // Spring Boot
     implementation 'org.springframework.boot:spring-boot-starter-web'
-    compileOnly 'org.projectlombok:lombok'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+    // Swagger (OpenAPI)
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
+
+    // MySQL
     runtimeOnly 'com.mysql:mysql-connector-j'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/com/ktb16_backend/config/SwaggerConfig.java
+++ b/src/main/java/com/ktb16_backend/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.ktb16_backend.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("AI Calendar API")
+                        .description("사진 → AI → 일정 추출 및 캘린더/To-Do 관리 API")
+                        .version("v1.0.0"));
+    }
+}

--- a/src/main/java/com/ktb16_backend/controller/AIResultController.java
+++ b/src/main/java/com/ktb16_backend/controller/AIResultController.java
@@ -1,0 +1,22 @@
+package com.ktb16_backend.controller;
+
+import com.ktb16_backend.dto.AIResultRequest;
+import com.ktb16_backend.dto.AIResultResponse;
+import com.ktb16_backend.service.AIResultService;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/ai-results")
+public class AIResultController {
+
+    private final AIResultService aiResultService;
+
+    public AIResultController(AIResultService aiResultService) {
+        this.aiResultService = aiResultService;
+    }
+
+    @PostMapping
+    public AIResultResponse save(@RequestBody AIResultRequest request) {
+        return aiResultService.save(request);
+    }
+}

--- a/src/main/java/com/ktb16_backend/controller/CalendarEventController.java
+++ b/src/main/java/com/ktb16_backend/controller/CalendarEventController.java
@@ -1,0 +1,29 @@
+package com.ktb16_backend.controller;
+
+import com.ktb16_backend.dto.ApiResponse;
+import com.ktb16_backend.dto.CalendarSaveRequest;
+import com.ktb16_backend.dto.CalendarSaveResponse;
+import com.ktb16_backend.service.CalendarEventService;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/calendar")
+public class CalendarEventController {
+
+    private final CalendarEventService calendarEventService;
+
+    public CalendarEventController(CalendarEventService calendarEventService) {
+        this.calendarEventService = calendarEventService;
+    }
+
+    @PostMapping("/save")
+    public ApiResponse<List<CalendarSaveResponse>> save(
+            @RequestBody CalendarSaveRequest request
+    ) {
+        return ApiResponse.ok(
+                calendarEventService.saveFromAIResult(request.aiResultId)
+        );
+    }
+}

--- a/src/main/java/com/ktb16_backend/controller/CalendarQueryController.java
+++ b/src/main/java/com/ktb16_backend/controller/CalendarQueryController.java
@@ -1,0 +1,35 @@
+package com.ktb16_backend.controller;
+
+import com.ktb16_backend.dto.CalendarEventResponse;
+import com.ktb16_backend.service.CalendarQueryService;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/calendar")
+public class CalendarQueryController {
+
+    private final CalendarQueryService calendarQueryService;
+
+    public CalendarQueryController(CalendarQueryService calendarQueryService) {
+        this.calendarQueryService = calendarQueryService;
+    }
+
+    // 전체 조회
+    @GetMapping
+    public List<CalendarEventResponse> findAll() {
+        return calendarQueryService.findAll();
+    }
+
+    // 기간 조회 (월별/범위)
+    @GetMapping("/range")
+    public List<CalendarEventResponse> findByRange(
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate start,
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate end
+    ) {
+        return calendarQueryService.findByRange(start, end);
+    }
+}

--- a/src/main/java/com/ktb16_backend/controller/HealthController.java
+++ b/src/main/java/com/ktb16_backend/controller/HealthController.java
@@ -1,0 +1,13 @@
+package com.ktb16_backend.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class HealthController {
+
+    @GetMapping("/health")
+    public String health() {
+        return "OK";
+    }
+}

--- a/src/main/java/com/ktb16_backend/controller/TodoCommandController.java
+++ b/src/main/java/com/ktb16_backend/controller/TodoCommandController.java
@@ -1,0 +1,44 @@
+package com.ktb16_backend.controller;
+
+import com.ktb16_backend.domain.CalendarEvent;
+import com.ktb16_backend.dto.ApiResponse;
+import com.ktb16_backend.exception.NotFoundException;
+import com.ktb16_backend.repository.CalendarEventRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/todos")
+public class TodoCommandController {
+
+    private final CalendarEventRepository calendarEventRepository;
+
+    public TodoCommandController(CalendarEventRepository calendarEventRepository) {
+        this.calendarEventRepository = calendarEventRepository;
+    }
+
+    @PatchMapping("/{id}/toggle")
+    public ApiResponse<Boolean> toggle(@PathVariable Long id) {
+
+        CalendarEvent event = calendarEventRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Todo not found"));
+
+        event.setDone(!event.isDone());
+
+        return ApiResponse.ok(event.isDone());
+    }
+
+    @PatchMapping("/{id}/memo")
+    public ApiResponse<Void> updateMemo(
+            @PathVariable Long id,
+            @RequestBody Map<String, String> body
+    ) {
+        CalendarEvent event = calendarEventRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException("Todo not found"));
+
+        event.setMemo(body.get("memo"));
+
+        return ApiResponse.ok(null);
+    }
+}

--- a/src/main/java/com/ktb16_backend/controller/TodoQueryController.java
+++ b/src/main/java/com/ktb16_backend/controller/TodoQueryController.java
@@ -1,0 +1,30 @@
+package com.ktb16_backend.controller;
+
+import com.ktb16_backend.domain.CalendarEvent;
+import com.ktb16_backend.dto.ApiResponse;
+import com.ktb16_backend.repository.CalendarEventRepository;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/todos")
+public class TodoQueryController {
+
+    private final CalendarEventRepository calendarEventRepository;
+
+    public TodoQueryController(CalendarEventRepository calendarEventRepository) {
+        this.calendarEventRepository = calendarEventRepository;
+    }
+
+    @GetMapping
+    public ApiResponse<List<CalendarEvent>> findTodos(
+            @RequestParam(required = false) Boolean done
+    ) {
+        if (done == null) {
+            return ApiResponse.ok(calendarEventRepository.findAll());
+        }
+
+        return ApiResponse.ok(calendarEventRepository.findByIsDone(done));
+    }
+}

--- a/src/main/java/com/ktb16_backend/domain/AIResult.java
+++ b/src/main/java/com/ktb16_backend/domain/AIResult.java
@@ -1,0 +1,139 @@
+package com.ktb16_backend.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "ai_result")
+public class AIResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String summary;
+
+    @Column(nullable = false, length = 50)
+    private String category;
+
+    @Column(name = "date_type", nullable = false, length = 50)
+    private String dateType; // SINGLE / RANGE / MULTIPLE
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Column(name = "raw_text", columnDefinition = "TEXT")
+    private String rawText;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    // 관계
+    // AI_RESULT (1) : AI_RESULT_DATE (0..N) - 식별 관계
+    @OneToMany(
+            mappedBy = "aiResult",
+            cascade = CascadeType.ALL,
+            orphanRemoval = true
+    )
+    private List<AIResultDate> dates = new ArrayList<>();
+
+    // AI_RESULT (1) : CALENDAR_EVENT (0..N) - 비식별 관계
+    @OneToMany(mappedBy = "aiResult")
+    private List<CalendarEvent> calendarEvents = new ArrayList<>();
+
+    // 생성 시각 자동 세팅
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 연관관계 편의 메서드
+    public void addDate(LocalDate date) {
+        this.dates.add(new AIResultDate(this, date));
+    }
+
+    // (연관관계 제외)
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public void setSummary(String summary) {
+        this.summary = summary;
+    }
+
+    public void setCategory(String category) {
+        this.category = category;
+    }
+
+    public void setDateType(String dateType) {
+        this.dateType = dateType;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public void setRawText(String rawText) {
+        this.rawText = rawText;
+    }
+
+    // getter
+    public Long getId() {
+        return id;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public String getSummary() {
+        return summary;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public String getDateType() {
+        return dateType;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public String getRawText() {
+        return rawText;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public List<AIResultDate> getDates() {
+        return dates;
+    }
+
+    public List<CalendarEvent> getCalendarEvents() {
+        return calendarEvents;
+    }
+}

--- a/src/main/java/com/ktb16_backend/domain/AIResultDate.java
+++ b/src/main/java/com/ktb16_backend/domain/AIResultDate.java
@@ -1,0 +1,44 @@
+package com.ktb16_backend.domain;
+
+import jakarta.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "ai_result_date")
+public class AIResultDate {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 식별 관계: AI_RESULT에 종속
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_result_id", nullable = false)
+    private AIResult aiResult;
+
+    @Column(nullable = false)
+    private LocalDate date;
+
+    // JPA 기본 생성자
+    protected AIResultDate() {
+    }
+
+    // 실제 사용하는 생성자
+    public AIResultDate(AIResult aiResult, LocalDate date) {
+        this.aiResult = aiResult;
+        this.date = date;
+    }
+
+    // getter
+    public Long getId() {
+        return id;
+    }
+
+    public AIResult getAiResult() {
+        return aiResult;
+    }
+
+    public LocalDate getDate() {
+        return date;
+    }
+}

--- a/src/main/java/com/ktb16_backend/domain/CalendarEvent.java
+++ b/src/main/java/com/ktb16_backend/domain/CalendarEvent.java
@@ -1,0 +1,124 @@
+package com.ktb16_backend.domain;
+
+import jakarta.persistence.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "calendar_event")
+public class CalendarEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 연관 관계
+    // AI_RESULT (1) : CALENDAR_EVENT (0..N)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "ai_result_id", nullable = false)
+    private AIResult aiResult;
+
+    // 기본 정보
+    @Column(nullable = false)
+    private String title;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDate startDate;
+
+    @Column(name = "end_date", nullable = false)
+    private LocalDate endDate;
+
+    // To-Do
+    @Column(name = "is_done", nullable = false)
+    private boolean isDone = false;
+
+    @Column(length = 255)
+    private String memo;
+
+    // 생성 시각
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    protected CalendarEvent() {
+        // JPA 기본 생성자
+    }
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    // 팩토리 메서드
+    public static CalendarEvent create(
+            AIResult aiResult,
+            String title,
+            LocalDate startDate,
+            LocalDate endDate
+    ) {
+        CalendarEvent event = new CalendarEvent();
+        event.aiResult = aiResult;
+        event.title = title;
+        event.startDate = startDate;
+        event.endDate = endDate;
+        event.isDone = false;
+        return event;
+    }
+
+    // getter / setter
+    public Long getId() {
+        return id;
+    }
+
+    public AIResult getAiResult() {
+        return aiResult;
+    }
+
+    public void setAiResult(AIResult aiResult) {
+        this.aiResult = aiResult;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
+    }
+
+    public LocalDate getStartDate() {
+        return startDate;
+    }
+
+    public void setStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public LocalDate getEndDate() {
+        return endDate;
+    }
+
+    public void setEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public boolean isDone() {
+        return isDone;
+    }
+
+    public void setDone(boolean done) {
+        isDone = done;
+    }
+
+    public String getMemo() {
+        return memo;
+    }
+
+    public void setMemo(String memo) {
+        this.memo = memo;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+}

--- a/src/main/java/com/ktb16_backend/dto/AIResultRequest.java
+++ b/src/main/java/com/ktb16_backend/dto/AIResultRequest.java
@@ -1,0 +1,20 @@
+package com.ktb16_backend.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AIResultRequest {
+
+    public String title;
+    public String summary;
+    public String category;
+    public String dateType; // SINGLE / RANGE / MULTIPLE
+
+    public LocalDate startDate;
+    public LocalDate endDate;
+
+    // MULTIPLE일 때만 사용
+    public List<LocalDate> dates;
+
+    public String rawText;
+}

--- a/src/main/java/com/ktb16_backend/dto/AIResultResponse.java
+++ b/src/main/java/com/ktb16_backend/dto/AIResultResponse.java
@@ -1,0 +1,17 @@
+package com.ktb16_backend.dto;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public class AIResultResponse {
+
+    public Long id;
+    public String title;
+    public String summary;
+    public String category;
+    public String dateType;
+
+    public LocalDate startDate;
+    public LocalDate endDate;
+    public List<LocalDate> dates;
+}

--- a/src/main/java/com/ktb16_backend/dto/ApiResponse.java
+++ b/src/main/java/com/ktb16_backend/dto/ApiResponse.java
@@ -1,0 +1,22 @@
+package com.ktb16_backend.dto;
+
+public class ApiResponse<T> {
+
+    public boolean success;
+    public T data;
+    public String error;
+
+    private ApiResponse(boolean success, T data, String error) {
+        this.success = success;
+        this.data = data;
+        this.error = error;
+    }
+
+    public static <T> ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(true, data, null);
+    }
+
+    public static <T> ApiResponse<T> error(String error) {
+        return new ApiResponse<>(false, null, error);
+    }
+}

--- a/src/main/java/com/ktb16_backend/dto/CalendarEventResponse.java
+++ b/src/main/java/com/ktb16_backend/dto/CalendarEventResponse.java
@@ -1,0 +1,11 @@
+package com.ktb16_backend.dto;
+
+import java.time.LocalDate;
+
+public class CalendarEventResponse {
+
+    public Long id;
+    public String title;
+    public LocalDate startDate;
+    public LocalDate endDate;
+}

--- a/src/main/java/com/ktb16_backend/dto/CalendarSaveRequest.java
+++ b/src/main/java/com/ktb16_backend/dto/CalendarSaveRequest.java
@@ -1,0 +1,5 @@
+package com.ktb16_backend.dto;
+
+public class CalendarSaveRequest {
+    public Long aiResultId;
+}

--- a/src/main/java/com/ktb16_backend/dto/CalendarSaveResponse.java
+++ b/src/main/java/com/ktb16_backend/dto/CalendarSaveResponse.java
@@ -1,0 +1,11 @@
+package com.ktb16_backend.dto;
+
+import java.time.LocalDate;
+
+public class CalendarSaveResponse {
+
+    public Long calendarEventId;
+    public String title;
+    public LocalDate startDate;
+    public LocalDate endDate;
+}

--- a/src/main/java/com/ktb16_backend/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/ktb16_backend/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.ktb16_backend.exception;
+
+import com.ktb16_backend.dto.ApiResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    public Object handleException(Exception e, HttpServletRequest request) {
+
+        String uri = request.getRequestURI();
+
+        // Swagger / OpenAPI 요청은 예외 처리에서 제외
+        if (uri.startsWith("/v3/api-docs")
+                || uri.startsWith("/swagger-ui")
+                || uri.startsWith("/swagger-ui.html")) {
+            return null;
+        }
+
+        return ApiResponse.error("Internal Server Error");
+    }
+}

--- a/src/main/java/com/ktb16_backend/exception/NotFoundException.java
+++ b/src/main/java/com/ktb16_backend/exception/NotFoundException.java
@@ -1,0 +1,7 @@
+package com.ktb16_backend.exception;
+
+public class NotFoundException extends RuntimeException {
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/ktb16_backend/repository/AIResultDateRepository.java
+++ b/src/main/java/com/ktb16_backend/repository/AIResultDateRepository.java
@@ -1,0 +1,12 @@
+package com.ktb16_backend.repository;
+
+import com.ktb16_backend.domain.AIResultDate;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface AIResultDateRepository extends JpaRepository<AIResultDate, Long> {
+
+    // 특정 AI_RESULT의 날짜 목록 조회
+    List<AIResultDate> findByAiResultId(Long aiResultId);
+}

--- a/src/main/java/com/ktb16_backend/repository/AIResultRepository.java
+++ b/src/main/java/com/ktb16_backend/repository/AIResultRepository.java
@@ -1,0 +1,7 @@
+package com.ktb16_backend.repository;
+
+import com.ktb16_backend.domain.AIResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AIResultRepository extends JpaRepository<AIResult, Long> {
+}

--- a/src/main/java/com/ktb16_backend/repository/CalendarEventRepository.java
+++ b/src/main/java/com/ktb16_backend/repository/CalendarEventRepository.java
@@ -1,0 +1,24 @@
+package com.ktb16_backend.repository;
+
+import com.ktb16_backend.domain.CalendarEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface CalendarEventRepository extends JpaRepository<CalendarEvent, Long> {
+
+    // 캘린더 조회
+    // 전체 조회 (날짜순)
+    List<CalendarEvent> findAllByOrderByStartDateAsc();
+
+    // 기간 조회 (월별 / 범위)
+    List<CalendarEvent> findByStartDateBetweenOrderByStartDateAsc(
+            LocalDate start,
+            LocalDate end
+    );
+
+    // To-Do 조회
+    // 완료 / 미완료 To-Do 조회
+    List<CalendarEvent> findByIsDone(boolean isDone);
+}

--- a/src/main/java/com/ktb16_backend/service/AIResultService.java
+++ b/src/main/java/com/ktb16_backend/service/AIResultService.java
@@ -1,0 +1,65 @@
+package com.ktb16_backend.service;
+
+import com.ktb16_backend.domain.AIResult;
+import com.ktb16_backend.domain.AIResultDate;
+import com.ktb16_backend.dto.AIResultRequest;
+import com.ktb16_backend.dto.AIResultResponse;
+import com.ktb16_backend.repository.AIResultRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.stream.Collectors;
+
+@Service
+@Transactional
+public class AIResultService {
+
+    private final AIResultRepository aiResultRepository;
+
+    public AIResultService(AIResultRepository aiResultRepository) {
+        this.aiResultRepository = aiResultRepository;
+    }
+
+    public AIResultResponse save(AIResultRequest request) {
+
+        AIResult aiResult = new AIResult();
+
+        // 기본 필드 세팅
+        aiResult.setTitle(request.title);
+        aiResult.setSummary(request.summary);
+        aiResult.setCategory(request.category);
+        aiResult.setDateType(request.dateType);
+        aiResult.setStartDate(request.startDate);
+        aiResult.setEndDate(request.endDate);
+        aiResult.setRawText(request.rawText);
+
+        // MULTIPLE 날짜 처리
+        if ("MULTIPLE".equals(request.dateType) && request.dates != null) {
+            request.dates.forEach(aiResult::addDate);
+        }
+
+        AIResult saved = aiResultRepository.save(aiResult);
+
+        return toResponse(saved);
+    }
+
+    // Entity → Response
+    private AIResultResponse toResponse(AIResult aiResult) {
+        AIResultResponse res = new AIResultResponse();
+
+        res.id = aiResult.getId();
+        res.title = aiResult.getTitle();
+        res.summary = aiResult.getSummary();
+        res.category = aiResult.getCategory();
+        res.dateType = aiResult.getDateType();
+        res.startDate = aiResult.getStartDate();
+        res.endDate = aiResult.getEndDate();
+
+        res.dates = aiResult.getDates()
+                .stream()
+                .map(AIResultDate::getDate)
+                .collect(Collectors.toList());
+
+        return res;
+    }
+}

--- a/src/main/java/com/ktb16_backend/service/CalendarEventService.java
+++ b/src/main/java/com/ktb16_backend/service/CalendarEventService.java
@@ -1,0 +1,93 @@
+package com.ktb16_backend.service;
+
+import com.ktb16_backend.domain.AIResult;
+import com.ktb16_backend.domain.AIResultDate;
+import com.ktb16_backend.domain.CalendarEvent;
+import com.ktb16_backend.dto.CalendarSaveResponse;
+import com.ktb16_backend.exception.NotFoundException;
+import com.ktb16_backend.repository.AIResultRepository;
+import com.ktb16_backend.repository.CalendarEventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@Transactional
+public class CalendarEventService {
+
+    private final AIResultRepository aiResultRepository;
+    private final CalendarEventRepository calendarEventRepository;
+
+    public CalendarEventService(
+            AIResultRepository aiResultRepository,
+            CalendarEventRepository calendarEventRepository
+    ) {
+        this.aiResultRepository = aiResultRepository;
+        this.calendarEventRepository = calendarEventRepository;
+    }
+
+    public List<CalendarSaveResponse> saveFromAIResult(Long aiResultId) {
+
+        AIResult aiResult = aiResultRepository.findById(aiResultId)
+                .orElseThrow(() -> new NotFoundException("AI_RESULT not found"));
+
+        List<CalendarEvent> events = new ArrayList<>();
+
+        switch (aiResult.getDateType()) {
+
+            case "SINGLE" -> {
+                events.add(
+                        CalendarEvent.create(
+                                aiResult,
+                                aiResult.getTitle(),
+                                aiResult.getStartDate(),
+                                aiResult.getStartDate()
+                        )
+                );
+            }
+
+            case "RANGE" -> {
+                events.add(
+                        CalendarEvent.create(
+                                aiResult,
+                                aiResult.getTitle(),
+                                aiResult.getStartDate(),
+                                aiResult.getEndDate()
+                        )
+                );
+            }
+
+            case "MULTIPLE" -> {
+                for (AIResultDate date : aiResult.getDates()) {
+                    events.add(
+                            CalendarEvent.create(
+                                    aiResult,
+                                    aiResult.getTitle(),
+                                    date.getDate(),
+                                    date.getDate()
+                            )
+                    );
+                }
+            }
+
+            default -> throw new IllegalStateException("Unknown dateType");
+        }
+
+        List<CalendarEvent> savedEvents = calendarEventRepository.saveAll(events);
+
+        return savedEvents.stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private CalendarSaveResponse toResponse(CalendarEvent event) {
+        CalendarSaveResponse response = new CalendarSaveResponse();
+        response.calendarEventId = event.getId();
+        response.title = event.getTitle();
+        response.startDate = event.getStartDate();
+        response.endDate = event.getEndDate();
+        return response;
+    }
+}

--- a/src/main/java/com/ktb16_backend/service/CalendarQueryService.java
+++ b/src/main/java/com/ktb16_backend/service/CalendarQueryService.java
@@ -1,0 +1,48 @@
+package com.ktb16_backend.service;
+
+import com.ktb16_backend.domain.CalendarEvent;
+import com.ktb16_backend.dto.CalendarEventResponse;
+import com.ktb16_backend.repository.CalendarEventRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+public class CalendarQueryService {
+
+    private final CalendarEventRepository calendarEventRepository;
+
+    public CalendarQueryService(CalendarEventRepository calendarEventRepository) {
+        this.calendarEventRepository = calendarEventRepository;
+    }
+
+    public List<CalendarEventResponse> findAll() {
+        return calendarEventRepository.findAllByOrderByStartDateAsc()
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    public List<CalendarEventResponse> findByRange(
+            LocalDate start,
+            LocalDate end
+    ) {
+        return calendarEventRepository
+                .findByStartDateBetweenOrderByStartDateAsc(start, end)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+    private CalendarEventResponse toResponse(CalendarEvent event) {
+        CalendarEventResponse res = new CalendarEventResponse();
+        res.id = event.getId();
+        res.title = event.getTitle();
+        res.startDate = event.getStartDate();
+        res.endDate = event.getEndDate();
+        return res;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,17 @@
+spring:
+  datasource:
+    url: jdbc:mysql://localhost:3306/ktb16?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
+    username: root
+    password: Amysm9022@
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+server:
+  port: 8080

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,17 +1,57 @@
 spring:
+  application:
+    name: ktb16-backend
+
   datasource:
-    url: jdbc:mysql://localhost:3306/ktb16?useSSL=false&allowPublicKeyRetrieval=true&serverTimezone=Asia/Seoul
-    username: root
-    password: Amysm9022@
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:3306}/${DB_NAME:ktb16}?useSSL=true&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:password}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     hibernate:
-      ddl-auto: validate
-    show-sql: true
+      ddl-auto: ${DDL_AUTO:update}
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.MySQLDialect
         format_sql: true
+        show_sql: ${SHOW_SQL:false}
+    open-in-view: false
+
+  # Connection pool settings for production
+  hikari:
+    maximum-pool-size: ${DB_POOL_SIZE:10}
+    minimum-idle: 5
+    connection-timeout: 30000
+    idle-timeout: 600000
+    max-lifetime: 1800000
 
 server:
-  port: 8080
+  port: ${SERVER_PORT:8080}
+  shutdown: graceful
+
+  # Error handling
+  error:
+    include-message: always
+    include-binding-errors: always
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,metrics
+      base-path: /actuator
+  endpoint:
+    health:
+      show-details: when-authorized
+  health:
+    defaults:
+      enabled: true
+
+logging:
+  level:
+    root: ${LOG_LEVEL:INFO}
+    com: ${APP_LOG_LEVEL:DEBUG}
+  pattern:
+    console: "%d{yyyy-MM-dd HH:mm:ss} - %msg%n"
+    file: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"


### PR DESCRIPTION
AI 기반 일정 추출 서비스의 백엔드 초기 인프라를 구축했습니다.

작업 내용
- ERD 기반 MySQL 테이블 생성
  - ai_result
  - ai_result_date
  - calendar_event
 
- application.yml 기반 환경 설정 전환
- Spring Boot + JPA + MySQL 연동
- Swagger(OpenAPI) 설정 (하는 중)
- GlobalExceptionHandler와 Swagger 충돌 이슈 해결

기술 포인트
- Swagger OpenAPI 엔드포인트(`/v3/api-docs`)를
  전역 예외 처리 대상에서 제외하여 문서화 정상 동작

Swagger
http://localhost:8080/swagger-ui/index.html